### PR TITLE
Resolving review comments

### DIFF
--- a/libs/langchain/tests/integration_tests/retrievers/document_compressors/test_encoded_chain_extract.py
+++ b/libs/langchain/tests/integration_tests/retrievers/document_compressors/test_encoded_chain_extract.py
@@ -3,16 +3,26 @@ import pytest
 
 from langchain.llms import OpenAI
 from langchain.retrievers.document_compressors import LLMEncodedChainExtractor
+from langchain.retrievers.document_compressors.encoded_chain_extract import (
+    number_sequences,
+)
 from langchain.schema import Document
 
 
 @pytest.mark.requires("spacy")
-def test_llm_construction_with_kwargs() -> None:
-    llm_chain_kwargs = {"verbose": True}
-    compressor = LLMEncodedChainExtractor.from_llm(
-        OpenAI(), llm_chain_kwargs=llm_chain_kwargs
+def test_number_sequences() -> None:
+    assert number_sequences("foo") == "#|1|# foo"
+    assert number_sequences("foo bar") == "#|1|# foo bar"
+    assert number_sequences("foo\nbar") == "#|1|# foo\nbar"
+    assert number_sequences("foo\n\nbar") == "#|1|# foo  \n\n  #|2|# bar"
+    assert (
+        number_sequences("foo\n\nbar\n\nbaz", 2)
+        == "#|1|# foo  \n\n   bar  \n\n  #|2|# baz"
     )
-    assert compressor.llm_chain.verbose is True
+    assert (
+        number_sequences("foo\n\n\nbar\n\n\nbaz", 4)
+        == "#|1|# foo  \n\n   bar  \n\n   baz"
+    )
 
 
 @pytest.mark.requires("spacy")

--- a/libs/langchain/tests/unit_tests/retrievers/document_compressors/test_encoded_chain_extract.py
+++ b/libs/langchain/tests/unit_tests/retrievers/document_compressors/test_encoded_chain_extract.py
@@ -4,7 +4,6 @@ import pytest
 from langchain.retrievers.document_compressors.encoded_chain_extract import (
     SequenceListParser,
     extract_numbered_sequences,
-    number_sequences,
 )
 from langchain.schema.output_parser import OutputParserException
 
@@ -19,22 +18,6 @@ def test_parser() -> None:
         assert parser.parse("1,6,10-8")
     with pytest.raises(OutputParserException):
         assert parser.parse("1,6,a")
-
-
-@pytest.mark.requires("spacy")
-def test_number_sequences() -> None:
-    assert number_sequences("foo") == "#|1|# foo"
-    assert number_sequences("foo bar") == "#|1|# foo bar"
-    assert number_sequences("foo\nbar") == "#|1|# foo\nbar"
-    assert number_sequences("foo\n\nbar") == "#|1|# foo  \n\n  #|2|# bar"
-    assert (
-        number_sequences("foo\n\nbar\n\nbaz", 2)
-        == "#|1|# foo  \n\n   bar  \n\n  #|2|# baz"
-    )
-    assert (
-        number_sequences("foo\n\n\nbar\n\n\nbaz", 4)
-        == "#|1|# foo  \n\n   bar  \n\n   baz"
-    )
 
 
 def test_extract_numbered_sequences() -> None:


### PR DESCRIPTION
This PR does the following:
1. Relocates the `test_number_sequences` test case from unit tests to integration tests.
2. Changes the type of `llm_chain` to a `Runnable` and uses `invoke` instead of `predict`.