### PR TITLE
feat: Add RetrySqlQueryCreatorTool for handling failed SQL query generation

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/sqlcoder/toolkit.py
+++ b/libs/community/langchain_community/agent_toolkits/sqlcoder/toolkit.py
@@ -13,6 +13,7 @@ from langchain_community.tools import BaseTool
 from langchain_community.tools.sql_coder.tool import (
     QuerySparkSQLDataBaseTool,
     SqlQueryCreatorTool,
+    RetrySqlQueryCreatorTool
 )
 
 class SQLCoderToolkit(BaseToolkit):
@@ -54,6 +55,7 @@ class SQLCoderToolkit(BaseToolkit):
                 db=self.db, description=query_sql_database_tool_description
             ),
             QuerySQLCheckerTool(db=self.db, llm=self.llm),
+            RetrySqlQueryCreatorTool(sqlcreatorllm=self.sqlcreatorllm),
             SqlQueryCreatorTool(
                 sqlcreatorllm=self.sqlcreatorllm , 
                 db=self.db,

--- a/libs/community/langchain_community/tools/sql_coder/prompt.py
+++ b/libs/community/langchain_community/tools/sql_coder/prompt.py
@@ -1,8 +1,21 @@
 
 
 SQL_QUERY_CREATOR_RETRY  = """
-You have failed in the first attempt to generate correct sql query. Please try again to rewrite correct sql query.
-"""
+### Instructions:
+Your task is convert an incorrect query resulting from user question to a correct query which is databricks sql compatible.
+Adhere to these rules:
+- **Deliberately go through the question and database schema word by word** to appropriately answer the question
+- **Use Table Aliases** to prevent ambiguity. For example, `SELECT table1.col1, table2.col1 FROM table1 JOIN table2 ON table1.id = table2.id`.
+- When creating a ratio, always cast the numerator as float
+
+### Task:
+Generate a correct SQL query that answers the question [QUESTION]`{user_input}`[/QUESTION].
+The query you will correct is: {sql_query}
+The error message is: {error_message}
+
+### Response:
+Based on your instructions, here is the SQL query I have generated 
+[SQL]"""
 
 SQL_QUERY_CREATOR_7b = """
 ### Instructions:

--- a/libs/community/langchain_community/tools/sql_coder/tool.py
+++ b/libs/community/langchain_community/tools/sql_coder/tool.py
@@ -67,7 +67,7 @@ class QuerySparkSQLDataBaseTool(StateTool):
         executable_query = executable_query.strip('\"')
         executable_query = re.sub('\\n```', '',executable_query)
         self.db.run_no_throw(executable_query)
-        return self.db.run_no_throw(executable_query)
+        return self.db.run_no_throw(executable_query, include_columns=True)
 
     async def _arun(
         self,

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-community"
-version = "0.2.5dev1"
+version = "0.2.7dev1"
 description = "Community contributed LangChain integrations."
 authors = []
 license = "MIT"

--- a/libs/langchain/langchain/tools/sqlcoder/prompt.py
+++ b/libs/langchain/langchain/tools/sqlcoder/prompt.py
@@ -1,8 +1,20 @@
 
 
 SQL_QUERY_CREATOR_RETRY  = """
-You have failed in the first attempt to generate correct sql query. Please try again to rewrite correct sql query.
-"""
+Your task is convert an incorrect query resulting from user question to a correct query which is databricks sql compatible.
+Adhere to these rules:
+- **Deliberately go through the question and database schema word by word** to appropriately answer the question
+- **Use Table Aliases** to prevent ambiguity. For example, `SELECT table1.col1, table2.col1 FROM table1 JOIN table2 ON table1.id = table2.id`.
+- When creating a ratio, always cast the numerator as float
+
+### Task:
+Generate a correct SQL query that answers the question [QUESTION]`{user_input}`[/QUESTION].
+The query you will correct is: {sql_query}
+The error message is: {error_message}
+
+### Response:
+Based on your instructions, here is the SQL query I have generated 
+[SQL]"""
 
 SQL_QUERY_CREATOR_7b = """
 ### Instructions:

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain"
-version = "0.2.11dev1"
+version = "0.2.12dev1"
 description = "Building applications with LLMs through composability"
 authors = []
 license = "MIT"


### PR DESCRIPTION
Add RetrySqlQueryCreatorTool for handling failed SQL query generation

Thank you for contributing to LangChain!

If no one reviews your PR within a few days, please @-mention one of baskaryan, efriis, eyurtsev, ccurme, vbarda, hwchase17.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a new tool, RetrySqlQueryCreatorTool, to handle failed SQL query generation by retrying the creation process. It also updates the existing SQL query creation workflow to integrate this new tool and enhances the prompt used for retrying SQL queries.

- **New Features**:
    - Introduced RetrySqlQueryCreatorTool to handle the re-creation of SQL queries when the initial query generation fails.
- **Enhancements**:
    - Updated the SQL query creation process to use RetrySqlQueryCreatorTool for handling errors and retrying query generation.
    - Enhanced the SQL_QUERY_CREATOR_RETRY prompt to provide more detailed instructions for correcting SQL queries.

<!-- Generated by sourcery-ai[bot]: end summary -->